### PR TITLE
Unicode strings can be sent as IntArray

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ adb shell am broadcast -a ADB_INPUT_CODE --ei code 67
 
 3. Sending editor action (2 = IME_ACTION_GO)
 adb shell am broadcast -a ADB_EDITOR_CODE --ei code 2
+
+4. Sending unicode characters
+To send 😸 Cat
+adb shell am broadcast -a ADB_INPUT_CHARS --eia chars '128568,32,67,97,116'
 </pre>
 
 Switch to ADBKeyBoard from adb (by [robertio](https://github.com/robertio)) :

--- a/src/com/android/adbkeyboard/AdbIME.java
+++ b/src/com/android/adbkeyboard/AdbIME.java
@@ -12,6 +12,7 @@ import android.view.inputmethod.InputConnection;
 public class AdbIME extends InputMethodService { 
 	
     private String IME_MESSAGE = "ADB_INPUT_TEXT";
+    private String IME_CHARS = "ADB_INPUT_CHARS";
     private String IME_KEYCODE = "ADB_INPUT_CODE";
     private String IME_EDITORCODE = "ADB_EDITOR_CODE";
     private BroadcastReceiver mReceiver = null;
@@ -25,6 +26,7 @@ public class AdbIME extends InputMethodService {
     
         if (mReceiver == null) {
         	IntentFilter filter = new IntentFilter(IME_MESSAGE);
+        	filter.addAction(IME_CHARS);
         	filter.addAction(IME_KEYCODE);
         	filter.addAction(IME_EDITORCODE);
         	mReceiver = new AdbReceiver();
@@ -49,6 +51,16 @@ public class AdbIME extends InputMethodService {
 			if (intent.getAction().equals(IME_MESSAGE)) {
 				String msg = intent.getStringExtra("msg");				
 				if (msg != null) {					
+					InputConnection ic = getCurrentInputConnection();
+					if (ic != null)
+						ic.commitText(msg, 1);
+				}
+			}
+			
+			if (intent.getAction().equals(IME_CHARS)) {
+				int[] chars = intent.getIntArrayExtra("chars");				
+				if (chars != null) {					
+					String msg = new String(chars, 0, chars.length);
 					InputConnection ic = getCurrentInputConnection();
 					if (ic != null)
 						ic.commitText(msg, 1);


### PR DESCRIPTION
This is a way to send [unicode characters](http://unicode-table.com/) because `ADB_INPUT_TEXT` does not work for characters such as emojis.

To send `😸 Cat` use the command
```
adb shell am broadcast -a ADB_INPUT_CHARS --eia chars '128568,32,67,97,116'
```

This is also a solution to issue https://github.com/senzhk/ADBKeyBoard/issues/3